### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Run the Murre model to perform SfM-guided monocular depth estimation:
 ```
 python run.py --checkpoint ${your_ckpt_path} --input_rgb_dir ${your_rgb_path} --input_sdpt_dir ${your_sparse_depth_path} --output_dir ${your_output_path} --denoise_steps 10 --ensemble_size 5 --processing_res ${your_desired_resolution} --max_depth 10.0
 ```
-For ​indoor scenes, we recommend setting `--max_depth=10.0`. For ​outdoor scenes, consider increasing this value(for example, 80.0).
+For ​indoor scenes, we recommend setting `--max_depth=10.0`. For ​outdoor scenes, consider increasing this value (for example, 80.0).
 
 To filter unreliable SfM depth estimates, adjust:
 
@@ -67,7 +67,7 @@ To filter unreliable SfM depth estimates, adjust:
 
 This ensures robustness by excluding noisy depth values with high errors or insufficient observations.
 
-Make sure that the same proccesing resolution is used as the first step.
+Make sure that the same processing resolution is used as the first step.
 
 ### TSDF fusion
 


### PR DESCRIPTION
fix: correct typo 'proccesing' → 'processing'

fix: add missing space before parenthesis in README