### PR TITLE
supported max image resolution for flag "--processing_res 0" and solve resolution matching issue, and added image name comparison for proofing agains input image count mismatch.

### DIFF
--- a/murre/pipeline.py
+++ b/murre/pipeline.py
@@ -218,12 +218,11 @@ class MurrePipeline(DiffusionPipeline):
         sdpt = input_sparse_depth
 
         # Resize image
-        if processing_res > 0:
-            rgb = resize_max_res(
-                rgb,
-                max_edge_resolution=processing_res,
-                resample_method=resample_method,
-            )
+        rgb = resize_max_res(
+            rgb,
+            max_edge_resolution=processing_res,
+            resample_method=resample_method,
+        )
 
         # Normalize rgb values
         rgb_norm: torch.Tensor = rgb / 255.0 * 2.0 - 1.0  #  [0, 255] -> [-1, 1]
@@ -231,6 +230,7 @@ class MurrePipeline(DiffusionPipeline):
         assert rgb_norm.min() >= -1.0 and rgb_norm.max() <= 1.0
 
         # ----------------- Sparse Depth Preprocess -----------------
+        logging.info(f"sdpt.shape {sdpt.shape} & rgb.shape[2:] {rgb.shape[2:]}")
         assert sdpt.shape == rgb.shape[2:]
         # Normalize depth
         sdpt_norm, d_min, d_max = normalize_depth(sdpt, pre_clip_max=max_depth)

--- a/murre/util/image_util.py
+++ b/murre/util/image_util.py
@@ -77,16 +77,19 @@ def resize_max_res(
     assert 4 == img.dim(), f"Invalid input shape {img.shape}"
 
     original_height, original_width = img.shape[-2:]
-    downscale_factor = min(
-        max_edge_resolution / original_width, max_edge_resolution / original_height
-    )
+
+    downscale_factor = 1.0
+    if max_edge_resolution > 0:
+        downscale_factor = min(
+            max_edge_resolution / original_width, max_edge_resolution / original_height
+        )
 
     new_width = int(original_width * downscale_factor)
     new_height = int(original_height * downscale_factor)
 
     resized_img = resize(img, (new_height, new_width), resample_method, antialias=True)
-    crop_h = new_height - new_height % 16
-    crop_w = new_width - new_width % 16
+    crop_h = new_height - new_height % 8 #16
+    crop_w = new_width - new_width % 8 #16
 
     resized_img = resized_img.squeeze().permute(1, 2, 0)[:crop_h, :crop_w, :]
     resized_img = resized_img.permute(2, 0, 1).unsqueeze(0)

--- a/run.py
+++ b/run.py
@@ -14,6 +14,19 @@ EXTENSION_LIST = [".jpg", ".jpeg", ".png"]
 SDPT_EXTENSION_LIST = [".npz"]
 
 
+def stem(p):
+    return os.path.splitext(os.path.basename(p))[0]
+
+def filter_common_files(set1, set2):
+    stems2 = {stem(p) for p in set2}
+    filtered1 = [p for p in set1 if stem(p) in stems2]
+
+    stems1 = {stem(p) for p in set1}
+    filtered2 = [p for p in set2 if stem(p) in stems1]
+
+    return filtered1, filtered2
+
+
 if "__main__" == __name__:
     logging.basicConfig(level=logging.INFO)
 
@@ -43,7 +56,10 @@ if "__main__" == __name__:
     )
 
     parser.add_argument(
-        "--output_dir", type=str, required=True, help="Output directory."
+        "--output_dir", 
+        type=str, 
+        required=True, 
+        help="Output directory."
     )
 
     # inference setting
@@ -208,22 +224,21 @@ if "__main__" == __name__:
         f for f in rgb_filename_list if os.path.splitext(f)[1].lower() in EXTENSION_LIST
     ]
     rgb_filename_list = sorted(rgb_filename_list)
-    n_images = len(rgb_filename_list)
-    if n_images > 0:
-        logging.info(f"Found {n_images} images")
-    else:
-        logging.error(f"No image found in '{input_rgb_dir}'")
-        exit(1)
+
     # sparse depth
     sdpt_filename_list = glob(os.path.join(input_sdpt_dir, "*"))
     sdpt_filename_list = [
         f for f in sdpt_filename_list if os.path.splitext(f)[1].lower() in SDPT_EXTENSION_LIST
     ]
     sdpt_filename_list = sorted(sdpt_filename_list)
-    if not len(sdpt_filename_list) == n_images:
-        logging.error(f'Number of sparse depth maps({len(sdpt_filename_list)}) is not the same as that of images({n_images})')
+
+    rgb_filename_list, sdpt_filename_list = filter_common_files(rgb_filename_list, sdpt_filename_list)
+    n_images = len(rgb_filename_list)
+    if n_images > 0:
+        logging.info(f"Matched {n_images} RGB images.")
+    else:
+        logging.error(f"No image matched between '{input_rgb_dir}' and '{input_sdpt_dir}'")
         exit(1)
-    
 
     # -------------------- Model --------------------
     if half_precision:

--- a/setupAndRunning.md
+++ b/setupAndRunning.md
@@ -1,0 +1,183 @@
+## Setup MURRE
+
+Create python environment:
+```
+screen -r
+conda create -p .conda/envs/murre python=3.10
+conda env list
+```
+
+Start new jupyter server:
+```
+./start_jupyter_server.sh [with image 'docker://nvcr.io#nvidia/pytorch:26.03-py3']
+```
+
+Open command prompt in the jupyter server and run:
+```
+conda activate murre
+conda install mamba
+mamba install cudatoolkit=11.8 pytorch==2.0.1 torchvision=0.15.2 torchtriton=2.0.0 -c pytorch -c nvidia
+```
+
+Download MURRE:
+```
+git clone https://github.com/zju3dv/Murre.git
+```
+
+## Majore changes
+
+make change to get_sfm_depth.py in function get_rescale_crop_tgthw-
+```
+def get_rescale_crop_tgthw(original_res, processing_res):
+    original_height, original_width = original_res
+
+    downscale_factor = 1.0
+    if processing_res > 0:
+        downscale_factor = min(
+            processing_res / original_width, processing_res / original_height
+        )
+        
+    new_width = int(original_width * downscale_factor)
+    new_height = int(original_height * downscale_factor)
+    crop_h = new_height - new_height % 8 #16
+    crop_w = new_width - new_width % 8 #16
+    return downscale_factor, crop_h, crop_w, new_height, new_width
+```
+
+add run.py after line 223-
+```
+    rgb_filename_list, sdpt_filename_list = filter_common_files(rgb_filename_list, sdpt_filename_list)
+    n_images = len(rgb_filename_list)
+    if n_images > 0:
+        logging.info(f"Matched {n_images} RGB images.")
+    else:
+        logging.error(f"No image matched between '{input_rgb_dir}' and '{input_sdpt_dir}'")
+        exit(1)
+```
+and remove line 211-216
+and these functions in the beginning-
+```
+def stem(p):
+    return os.path.splitext(os.path.basename(p))[0]
+
+def filter_common_files(set1, set2):
+    stems2 = {stem(p) for p in set2}
+    filtered1 = [p for p in set1 if stem(p) in stems2]
+
+    stems1 = {stem(p) for p in set1}
+    filtered2 = [p for p in set2 if stem(p) in stems1]
+
+    return filtered1, filtered2
+```
+
+## Run MURRE
+
+Note: Set --max_depth 10.0 for indoor and 80.0 for outdoor scenes
+
+Running on Scannet++:
+```
+cd /workspace/minhas/mono_depth/murre/
+conda activate murre
+
+mkdir -p /workspace/minhas/dataset/scannetpp/data/0b031f3119/dslr/murre_resized_undistorted_images/
+
+python sfm_depth/get_sfm_depth.py \
+    --input_sfm_dir  /workspace/minhas/dataset/scannetpp/data/0b031f3119/dslr/colmap_resized_undistorted_images/ \
+    --output_sfm_dir /workspace/minhas/dataset/scannetpp/data/0b031f3119/dslr/murre_resized_undistorted_images/ \
+    --processing_res 0
+
+python run.py \
+    --checkpoint     /workspace/minhas/mono_depth/murre/murre-ckpt/ \
+    --input_rgb_dir  /workspace/minhas/dataset/scannetpp/data/0b031f3119/dslr/resized_undistorted_images/ \
+    --input_sdpt_dir /workspace/minhas/dataset/scannetpp/data/0b031f3119/dslr/murre_resized_undistorted_images/sparse_depth/ \
+    --output_dir     /workspace/minhas/dataset/scannetpp/data/0b031f3119/dslr/murre_resized_undistorted_images/ \
+    --denoise_steps 10 --ensemble_size 5 --processing_res 0 --max_depth 10.0
+```
+
+Running on MipNeRF360:
+```
+cd /workspace/minhas/mono_depth/murre/
+conda activate murre
+
+img_id="garden"
+
+mkdir -p /workspace/minhas/dataset/mipnerf/${img_id}/murre_images_2/
+
+python sfm_depth/get_sfm_depth.py \
+    --input_sfm_dir  /workspace/minhas/dataset/mipnerf/${img_id}/colmap_images_2/ \
+    --output_sfm_dir /workspace/minhas/dataset/mipnerf/${img_id}/murre_images_2/ \
+    --processing_res 0
+
+python run.py \
+    --checkpoint     /workspace/minhas/mono_depth/murre/murre-ckpt/ \
+    --input_rgb_dir  /workspace/minhas/dataset/mipnerf/${img_id}/images_2/ \
+    --input_sdpt_dir /workspace/minhas/dataset/mipnerf/${img_id}/murre_images_2/sparse_depth/ \
+    --output_dir     /workspace/minhas/dataset/mipnerf/${img_id}/murre_images_2/ \
+    --denoise_steps 10 --ensemble_size 5 --processing_res 0 --max_depth 80.0
+```
+
+
+## Running GLOMAP
+
+On Scannet++:
+
+```
+cd /workspace/minhas/splat/glomap/build/glomap/
+conda activate glomap
+
+mkdir -p glomap_resized_undistorted_images
+mkdir -p colmap_resized_undistorted_images
+
+img_id="0a5c013435"
+
+colmap feature_extractor \
+    --image_path    /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/resized_undistorted_images/ \
+    --database_path /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/glomap_resized_undistorted_images/database.db \
+    --ImageReader.single_camera 1 \
+    --ImageReader.camera_model PINHOLE
+
+#colmap exhaustive_matcher \
+colmap sequential_matcher \
+    --database_path /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/glomap_resized_undistorted_images/database.db
+
+./glomap mapper \
+    --database_path /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/glomap_resized_undistorted_images/database.db \
+    --image_path    /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/resized_undistorted_images/ \
+    --output_path   /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/glomap_resized_undistorted_images/
+
+colmap model_converter \
+    --input_path  /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/glomap_resized_undistorted_images/0/ \
+    --output_path /workspace/minhas/dataset/scannetpp/data/${img_id}/dslr/colmap_resized_undistorted_images/ \
+    --output_type TXT
+```
+
+Running on MipNeRF360:
+```
+cd /workspace/minhas/splat/glomap/build/glomap/
+conda activate glomap
+
+img_id="room"
+
+mkdir -p /workspace/minhas/dataset/mipnerf/${img_id}/glomap_images_2/
+mkdir -p /workspace/minhas/dataset/mipnerf/${img_id}/colmap_images_2/
+
+colmap feature_extractor \
+    --image_path    /workspace/minhas/dataset/mipnerf/${img_id}/images_2/ \
+    --database_path /workspace/minhas/dataset/mipnerf/${img_id}/glomap_images_2/database.db \
+    --ImageReader.single_camera 1 \
+    --ImageReader.camera_model PINHOLE
+
+colmap sequential_matcher \
+    --database_path /workspace/minhas/dataset/mipnerf/${img_id}/glomap_images_2/database.db
+
+./glomap mapper \
+    --database_path /workspace/minhas/dataset/mipnerf/${img_id}/glomap_images_2/database.db \
+    --image_path    /workspace/minhas/dataset/mipnerf/${img_id}/images_2/ \
+    --output_path   /workspace/minhas/dataset/mipnerf/${img_id}/glomap_images_2/
+
+colmap model_converter \
+    --input_path  /workspace/minhas/dataset/mipnerf/${img_id}/glomap_images_2/0/ \
+    --output_path /workspace/minhas/dataset/mipnerf/${img_id}/colmap_images_2/ \
+    --output_type TXT
+
+```

--- a/sfm_depth/get_sfm_depth.py
+++ b/sfm_depth/get_sfm_depth.py
@@ -7,13 +7,17 @@ from colmap_util import read_model, get_intrinsics, get_hws, get_extrinsic
 
 def get_rescale_crop_tgthw(original_res, processing_res):
     original_height, original_width = original_res
-    downscale_factor = min(
-        processing_res / original_width, processing_res / original_height
-    )
+
+    downscale_factor = 1.0
+    if processing_res > 0:
+        downscale_factor = min(
+            processing_res / original_width, processing_res / original_height
+        )
+        
     new_width = int(original_width * downscale_factor)
     new_height = int(original_height * downscale_factor)
-    crop_h = new_height - new_height % 16
-    crop_w = new_width - new_width % 16
+    crop_h = new_height - new_height % 8 #16
+    crop_w = new_width - new_width % 8 #16
     return downscale_factor, crop_h, crop_w, new_height, new_width
 
 
@@ -84,6 +88,7 @@ if __name__ == '__main__':
     parser.add_argument(
         "--processing_res",
         type=int,
+        default=768,
         help="Maximum resolution of processing. 0 for using input image resolution. Default: 768.",
     )
 

--- a/tsdf_fusion.py
+++ b/tsdf_fusion.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     for image_file in image_files:
         img = cv2.imread(os.path.join(image_dir, image_file))
         img = cv2.resize(img, (w, h))
-        crop_h, crop_w = h - h % 16, w - w % 16
+        crop_h, crop_w = h - h % 8, w - w % 8 #16
         img = img[:crop_h, :crop_w, :]
         imgs.append(img)
 


### PR DESCRIPTION
I was working with scannet++ and mipnerf360 dataset. The current code was not supporting full image resolution for flag "--processing_res 0". So, I added some code to support this flag.

Also, colmap discards images if it cannot optimize camera parameters for them. This causes colmap out put to have lesser images than the input image count. So, I added file name matching in the code between images and sparse depths.